### PR TITLE
Fix nil crash when calling `unifieddyes.on_dig()` w/o PlayerRef

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -45,10 +45,11 @@ minetest.register_on_placenode(
 	end
 )
 
--- The complementary function:  strip-off the color if the node being dug is still white/neutral
+-- The complementary function: strip-off the color if the node being dug is still white/neutral
 -- adapted from
 -- https://github.com/minetest/minetest/blob/fe8d04d0b3c2e3af7c406fb6527f1b5230a30137/builtin/game/item.lua#L460-L562
 local function node_dig_without_color(pos, node, digger)
+	if not digger then return false end
 	local diggername = digger:get_player_name()
 
 	local def = ItemStack(node.name):get_definition()


### PR DESCRIPTION
Fixes #20 
Restores the old behavior from https://github.com/mt-mods/unifieddyes/blob/36c8bb5f5b8a0485225d2547c8978291ff710291/api.lua#L62-L63.