### PR TITLE
Replace Depracated `use_texture_alpha` Boolean

### DIFF
--- a/airbrush.lua
+++ b/airbrush.lua
@@ -473,7 +473,7 @@ end)
 minetest.register_tool("unifieddyes:airbrush", {
 	description = S("Dye Airbrush"),
 	inventory_image = "unifieddyes_airbrush.png",
-	use_texture_alpha = true,
+	use_texture_alpha = core.features.use_texture_alpha_string_modes and "opaque" or true,
 	tool_capabilities = {
 		full_punch_interval=0.1,
 	},


### PR DESCRIPTION
Replaces `use_texture_alpha` boolean value with string "opaque" in airbrush definition for newer servers.