### PR TITLE
Fix yield for vermilion recipe

### DIFF
--- a/dyes-crafting.lua
+++ b/dyes-crafting.lua
@@ -140,7 +140,7 @@ unifieddyes.palette_has_color["wallmounted_light_red"] = true
 
 unifieddyes.base_color_crafts = {
 	{ "red",		"flowers:rose",				nil,				nil,			nil,			nil,		4 },
-	{ "vermilion",	"dye:red",					"dye:orange",		nil,			nil,			nil,		3 },
+	{ "vermilion",	"dye:red",					"dye:orange",		nil,			nil,			nil,		2 },
 	{ "orange",		"flowers:tulip",			nil,				nil,			nil,			nil,		4 },
 	{ "orange",		"dye:red",					"dye:yellow",		nil,			nil,			nil,		2 },
 	{ "amber",		"dye:orange",				"dye:yellow",		nil,			nil,			nil,		2 },


### PR DESCRIPTION
Vermilion was the only case where 2 input dyes yielded 3 output dyes, so I assume this was a typo.

This PR changes the yield to 2, in order to be consistent with the other recipes.